### PR TITLE
Fix broken blog links

### DIFF
--- a/site/content/blog/fourth-riscv-workshop.md
+++ b/site/content/blog/fourth-riscv-workshop.md
@@ -9,7 +9,7 @@ been in Boston this week for the fourth RISC-V workshop. By any measure, this
 has been a massive success with over 250 attendees representing 63 companies 
 and 42 Universities. Wei presented our most recent work on integrating trace 
 debug, which you'll soon be able to read much more about here (it's worth 
-signing up to our [announcement list]({{< ref "about.md" >}}) if you want to 
+signing up to our [announcement list]({{< ref "about" >}}) if you want to
 be informed of each of our releases).
 
 ## RISC-V Foundation update: Rick O'Connor

--- a/site/content/blog/introducing-greg-and-tom/index.md
+++ b/site/content/blog/introducing-greg-and-tom/index.md
@@ -70,6 +70,6 @@ forward to what the future holds!"
 
 We’re thrilled to have Greg and Tom onboard to help propel our open source
 hardware efforts forward. We have a number of open job openings - take a look at
-our  [jobs page]({{< ref "jobs.md" >}}) to find out more.
+our  [jobs page]({{< ref "jobs" >}}) to find out more.
 
 _Alex Bradbury, CTO and Co-Founder_

--- a/site/content/blog/introducing-pirmin-and-laura/index.md
+++ b/site/content/blog/introducing-pirmin-and-laura/index.md
@@ -115,6 +115,6 @@ role and how it fits with things I’ve been working on.)"
 We're thrilled to have Pirmin and Laura join the lowRISC team and if you'd like
 to be part of the open source silicon revolution, we presently have a number
 of openings and I'd encourage you to take a look at the [jobs page]({{< ref
-"jobs.md" >}}).
+"jobs" >}}).
 
 _Alex Bradbury, CTO and Co-Founder_

--- a/site/content/blog/introducing-sam/index.md
+++ b/site/content/blog/introducing-sam/index.md
@@ -62,7 +62,7 @@ RISC-V and quickly get started on the platform."
 
 We're excited to have Sam join our team and help further accelerate our
 toolchain and LLVM-related efforts. If you're interested in joining us on our
-mission, check out our [jobs page]({{< ref "jobs.md" >}}) for details on
+mission, check out our [jobs page]({{< ref "jobs" >}}) for details on
 positions we are looking to fill.
 
 _Alex Bradbury, CTO and Co-Founder_

--- a/site/content/blog/lowrisc-expands-press-release/index.md
+++ b/site/content/blog/lowrisc-expands-press-release/index.md
@@ -53,7 +53,7 @@ a sustainable open source hardware ecosystem. In addition to engineering
 resources, lowRISC provides the community stewardship that is vital to this
 vision,” said Royal Hansen, vice president of Security, Google.
 
-Please visit our [jobs]({{< ref "jobs.md" >}}) page for more
+Please visit our [jobs]({{< ref "jobs" >}}) page for more
 information on how lowRISC is expanding our engineering organization.
 
 ## About lowRISC

--- a/site/content/blog/lowrisc-imc-interns-second-update/index.md
+++ b/site/content/blog/lowrisc-imc-interns-second-update/index.md
@@ -11,7 +11,7 @@ Financial Markets](http://www.imc.nl/) who are also helping to advise this
 summer project._
 
 At the time of our [last blog post]({{< ref
-"blog/lowrisc-imc-interns-week-one.md" >}}), we had just finished VGA and
+"blog/lowrisc-imc-interns-week-one" >}}), we had just finished VGA and
 were working on implementing the frame buffer. Over the last 2 weeks, we have
 made significant progress, completing the frame buffer and starting video decode.
 

--- a/site/content/blog/lowrisc-q-and-a.md
+++ b/site/content/blog/lowrisc-q-and-a.md
@@ -11,6 +11,6 @@ thread](https://news.ycombinator.com/item?id=13129076) became something of an
 impromptu Q+A about our project direction and status. I thought it was worth 
 linking to it here and highlighting the discussion for a wider audience. If 
 you have any additional questions, then feel free to comment on this blog post 
-or else, as always, drop by our [mailing list]({{< ref "community.md" >}}).
+or else, as always, drop by our [mailing list]({{< ref "community" >}}).
 
 _Alex Bradbury_

--- a/site/content/blog/onwards-and-upwards-at-lowrisc.md
+++ b/site/content/blog/onwards-and-upwards-at-lowrisc.md
@@ -6,7 +6,7 @@ title = "Onwards and upwards at lowRISC"
 +++
 
 If you haven't checked it out yet, be sure to take a look at our [press
-release]({{< ref "lowrisc-expands-press-release.md" >}}) and the
+release]({{< ref "blog/lowrisc-expands-press-release" >}}) and the
 [corresponding Google blog
 post](https://opensource.googleblog.com/2019/05/google-fosters-open-source-hardware.html).
 This industry support and growth of our board is a huge step forwards for
@@ -29,14 +29,14 @@ Google and other industry partners. Plus of course we’re continuing to lead th
 
 Over the last 6 months we've really entered a new phase of the lowRISC mission.
 We've grown from a single full-time engineer to five, with more on their way
-(check out our [active job adverts]({{< ref "jobs.md" >}}) - we'd love to hear
+(check out our [active job adverts]({{< ref "jobs" >}}) - we'd love to hear
 from you!). We've not been able to put out anywhere near as many updates as
 we'd like. The work we've been doing to grow the organisation and forge new
 collaborations is hugely time consuming, and of course embargos etc. come in to
 play. But you can expect to hear much more from us going forwards.
 
 On a final note, I'd like to shine the spotlight on the [whole lowRISC
-family]({{< ref "about.md" >}}), especially those who have helped us get this far. In
+family]({{< ref "about" >}}), especially those who have helped us get this far. In
 particular I’d like to thank our board of directors, our growing team of full
 time staff, our technical advisory board, and of course the wider community
 who have given us so much support, suggestions, and encouragement. Pirmin and

--- a/site/content/blog/risc-v-llvm-backend-in-9.0.md
+++ b/site/content/blog/risc-v-llvm-backend-in-9.0.md
@@ -18,7 +18,7 @@ users, this also makes it significantly easier for e.g. Rust/Julia/Swift and
 other languages using LLVM for code generation to do so using the
 system-provided LLVM libraries. This will make life easier for those working on
 RISC-V ports of Linux distros encountering issues with Rust dependencies. As
-[Sam mentioned yesterday]({{< ref "introducing-sam.md" >}}), we aim to work with the upstream
+[Sam mentioned yesterday]({{< ref "blog/introducing-sam" >}}), we aim to work with the upstream
 Rust community to help unblock this. 9.0 will branch on the 18th of July with
 the release scheduled for the 28th of August.
 
@@ -65,10 +65,10 @@ Support for RISC-V in LLVM is important for the wider RISC-V ecosystem and at
 lowRISC, we're proud of the role we've played in initiating its development,
 driving it forwards, and building a community around it. As an independent
 non-profit engineering organisation, we're uniquely positioned to perform this
-kind of work - [it's what we do]({{< ref "our-work.md" >}}). Our toolchain team has
+kind of work - [it's what we do]({{< ref "our-work" >}}). Our toolchain team has
 grown to include Luís Marques and Sam Elliott as well as myself and we are
 always interested in hearing from skilled engineers who’d like to [join our
-team]({{< ref "jobs.md" >}}). If you're interested in further supporting this work
+team]({{< ref "jobs" >}}). If you're interested in further supporting this work
 or in applying a similar approach to other open source hardware/software
 projects then get in touch at info@lowrisc.org.
 

--- a/site/content/blog/six-more-weeks-of-ibex-development/index.md
+++ b/site/content/blog/six-more-weeks-of-ibex-development/index.md
@@ -8,7 +8,7 @@ title = "Six more weeks of Ibex development - what's new?"
 In the past months, we have invested considerable effort in improving our
 RISC-V core [Ibex](https://github.com/lowRISC/ibex/). This 2-stage, in-order,
 32-bit microcontroller-class CPU core was [contributed to us]({{<
-ref "an-update-on-ibex-our-microcontroller-class-cpu-core.md" >}}) by ETH Zürich in
+ref "blog/an-update-on-ibex-our-microcontroller-class-cpu-core" >}}) by ETH Zürich in
 December 2018, with activity really ramping up since May. Having been taped out
 multiple times (as zero-riscy) in a mix of academic and industry projects, it
 came to us as a relatively mature code base. Despite this, we have continued to
@@ -83,6 +83,6 @@ GitHub! Our next priorities support for [Physical Memory Protection
 
 But why stop there? You can make hacking on Ibex and other exciting projects
 your day job! lowRISC is hiring, and you can find details on all of our current
-roles on our [jobs page]({{< ref "jobs.md" >}}).
+roles on our [jobs page]({{< ref "jobs" >}}).
 
 _Philipp Wagner and Pirmin Vogel_


### PR DESCRIPTION
Some broken links remain they're all to the docs which as far I can tell haven't been pulled over from the old site yet