### PR TITLE
[rss] Add default author

### DIFF
--- a/site/layouts/rss.xml
+++ b/site/layouts/rss.xml
@@ -15,7 +15,7 @@
       <link>{{ .Permalink }}</link>
       <guid>{{ .Permalink }}</guid>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Params.author }}<author>info@lowrisc.org ({{.}})</author>{{end}}
+      <author>info@lowrisc.org ({{.Params.author | default "lowRISC"}})</author>
       <description>{{ `<![CDATA[` | safeHTML }} {{ .Content | safeHTML }} ]]></description>
     </item>
     {{ end }}


### PR DESCRIPTION
Sets the author of rss articles to `lowRISC` if it's not set before.