### PR TITLE
Better solution for page titles

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -16,9 +16,6 @@ refLinksErrorLevel = "WARNING"
 
 timeout = 30000 #ms
 
-# Don't pluralize "blog" into "blogs" for blog list title
-pluralizeListTitles = false
-
 [blackfriday]
 plainIDAnchors = false
 

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <base href="{{ if getenv "CONTEXT" }}{{ cond (eq "production" (getenv "CONTEXT")) (getenv "URL") (getenv "DEPLOY_PRIME_URL") }}{{ else }}{{ $.Site.BaseURL }}{{ end }}">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
-  <title>{{with .Title }}{{.}} &middot; {{end}}{{ $.Site.Title }}</title>
+  <title>{{block "title" . }}{{.Title}} &middot; {{ $.Site.Title }}{{end}}</title>
 
   {{ with .OutputFormats.Get "rss" -}}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}

--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -1,3 +1,4 @@
+{{ define "title" }}The lowRISC Blog &middot; {{ $.Site.Title }}{{end}}
 {{ define "main" }} {{ $section := .Site.GetPage "section" .Section }}
 <div class="container lr-blog lr-blog-list">
   <h1>The lowRISC blog</h1>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,3 +1,4 @@
+{{ define "title" }}{{ $.Site.Title }}{{end}}
 {{ define "main" }}
 
 <div class="jumbotron jumbotron-fluid lr-home-mainjumbo">


### PR DESCRIPTION
The home page title is currently "lowrisc: collaborative … &middot; lowrisc: collaborative …" which is not exactly what we want.

This allows us to be more explicit about exactly which title we want, and avoids the problems with `pluralizeListTitles`