### PR TITLE
Add dates to blog entry list and place most recent entry on front page

### DIFF
--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -8,6 +8,7 @@
     <!-- this <div> includes the title summary -->
     <div class="media-body">
       <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+      <h5><time>{{ .PublishDate.Format "January 2, 2006" }}</time></h5>
       <p class="text-justify">
         {{ .Summary }}
       </p>

--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -4,39 +4,7 @@
   <h1>The lowRISC blog</h1>
 
   {{ range .Paginator.Pages }}
-  <article class="media">
-    <!-- this <div> includes the title summary -->
-    <div class="media-body">
-      <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
-      <h5><time>{{ .PublishDate.Format "January 2, 2006" }}</time></h5>
-      <p class="text-justify">
-        {{ .Summary }}
-      </p>
-
-      <p>
-        <a href="{{ .RelPermalink }}">Read More…</a>
-      </p>
-    </div>
-
-    {{ with .Resources.GetMatch (printf "*%s*" .Params.featured_image) }}
-      {{ if eq (path.Ext .) ".svg"}}
-        <img src="{{.Permalink}}"
-          alt="{{.Title}}" title="{{.Title}}"
-          class="align-self-center ml-3 d-none d-md-block"
-          width="150">
-      {{ else }}
-        {{ $img1x := .Resize "150x" }}
-        {{ $img2x := .Resize "300x" }}
-        <img
-          class="align-self-center rounded ml-3 d-none d-md-block"
-          alt="{{.Title}}" title="{{.Title}}"
-          srcset='
-            {{- with $img1x.RelPermalink }}{{.}} 1x, {{ end -}}
-            {{- with $img2x.RelPermalink }}{{.}} 2x {{ end -}}'
-          src="{{ with $img1x.RelPermalink }}{{.}}{{ end }}">
-      {{end}}
-    {{end}}
-  </article>
+  {{ partial "blog-summary.html" . }}
   {{ end }}
 
   <div class="lr-blog-list-pagination">

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -13,6 +13,12 @@
   </div>
 </div>
 
+<div class="container lr-blog lr-blog-list">
+  {{ range first 1 .Paginator.Pages }}
+  {{ partial "blog-summary.html" . }}
+  {{end}}
+</div>
+
   <!-- Marketing messaging and featurettes
   ================================================== -->
   <!-- Wrap the rest of the page in another container to center all the content. -->

--- a/site/layouts/partials/blog-summary.html
+++ b/site/layouts/partials/blog-summary.html
@@ -1,0 +1,33 @@
+<article class="media">
+  <!-- this <div> includes the title summary -->
+  <div class="media-body">
+    <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+    <h5><time>{{ .PublishDate.Format "January 2, 2006" }}</time></h5>
+    <p class="text-justify">
+      {{ .Summary }}
+    </p>
+
+    <p>
+      <a href="{{ .RelPermalink }}">Read More…</a>
+    </p>
+  </div>
+
+  {{ with .Resources.GetMatch (printf "*%s*" .Params.featured_image) }}
+    {{ if eq (path.Ext .) ".svg"}}
+      <img src="{{.Permalink}}"
+        alt="{{.Title}}" title="{{.Title}}"
+        class="align-self-center ml-3 d-none d-md-block"
+        width="150">
+    {{ else }}
+      {{ $img1x := .Resize "150x" }}
+      {{ $img2x := .Resize "300x" }}
+      <img
+        class="align-self-center rounded ml-3 d-none d-md-block"
+        alt="{{.Title}}" title="{{.Title}}"
+        srcset='
+          {{- with $img1x.RelPermalink }}{{.}} 1x, {{ end -}}
+          {{- with $img2x.RelPermalink }}{{.}} 2x {{ end -}}'
+        src="{{ with $img1x.RelPermalink }}{{.}}{{ end }}">
+    {{end}}
+  {{end}}
+</article>


### PR DESCRIPTION
## Summary

This PR:

* adds the submitted date alongside each blog entry on the list of entries (https://lowrisc.org/blog)
* adds the most recent blog entry to the front page of the website below the banner.

## Screenshots

![image](https://github.com/lowRISC/lowrisc-web/assets/105280833/65a0565b-d6d4-4126-a565-ed292f06a2ea)

![image](https://github.com/lowRISC/lowrisc-web/assets/105280833/a35dc6ad-8018-4c33-a376-4cfac5920608)
